### PR TITLE
Add pt-pt translations

### DIFF
--- a/res/layout/main.xml
+++ b/res/layout/main.xml
@@ -1,78 +1,79 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout android:layout_width="fill_parent"
-	android:layout_height="fill_parent" android:orientation="vertical"
-	xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/MainWindow"
-	android:gravity="top">
+    android:layout_height="fill_parent" android:orientation="vertical"
+    xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/MainWindow"
+    android:gravity="top">
 
-	<LinearLayout android:layout_width="fill_parent"
-	android:layout_height="0dp" android:orientation="vertical" android:layout_weight="1"
-	xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/RadioInfo"
-	android:gravity="center">
-		<!-- first line for PSN and PTY -->
-		<LinearLayout android:layout_width="fill_parent"
-		android:layout_height="wrap_content" android:orientation="horizontal"
-		xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/TopBar"
-		android:gravity="top">
-			<TextView android:layout_width="0dp"
-				android:lines="1" android:paddingLeft="16dp"
-				android:layout_height="wrap_content" android:text="@string/no_rds"
-				android:textSize="22dp" android:id="@+id/PSNTextView" android:gravity="left"
-				android:layout_weight="1" android:includeFontPadding="false"></TextView>
-			<TextView android:layout_width="wrap_content" android:lines="1" android:paddingRight="16dp"
-				android:layout_height="wrap_content"
-				android:textSize="16dp" android:id="@+id/PTYTextView" android:gravity="center_vertical|right"
-				android:layout_weight="1" android:includeFontPadding="false"></TextView>
-		</LinearLayout>
+    <LinearLayout android:layout_width="fill_parent"
+    android:layout_height="0dp" android:orientation="vertical" android:layout_weight="1"
+    xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/RadioInfo"
+    android:gravity="center">
+        <!-- first line for PSN and PTY -->
+        <LinearLayout android:layout_width="fill_parent"
+        android:layout_height="wrap_content" android:orientation="horizontal"
+        xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/TopBar"
+        android:gravity="top">
+            <TextView android:layout_width="0dp"
+                android:lines="1" android:paddingLeft="16dp"
+                android:layout_height="wrap_content" android:text="@string/no_rds"
+                android:textSize="22dp" android:id="@+id/PSNTextView" android:gravity="left"
+                android:layout_weight="1" android:includeFontPadding="false"></TextView>
+            <TextView android:layout_width="wrap_content" android:lines="1" android:paddingRight="16dp"
+                android:layout_height="wrap_content"
+                android:textSize="16dp" android:id="@+id/PTYTextView" android:gravity="center_vertical|right"
+                android:layout_weight="1" android:includeFontPadding="false"></TextView>
+        </LinearLayout>
 
-		<!-- frequency -->
-		<TextView android:layout_width="fill_parent" android:fontFamily="sans-serif-light"
-			android:layout_height="wrap_content" android:id="@+id/FrequencyTextView"
-			android:lines="1" android:textSize="105dp" android:gravity="center"
-			android:text="@string/dashes" android:includeFontPadding="false"></TextView>
+        <!-- frequency -->
+        <!-- <TextView android:layout_width="fill_parent" android:fontFamily="sans-serif-light" -->
+        <TextView android:layout_width="fill_parent" android:typeface="sans"
+            android:layout_height="wrap_content" android:id="@+id/FrequencyTextView"
+            android:lines="1" android:textSize="105dp" android:gravity="center"
+            android:text="@string/dashes" android:includeFontPadding="false"></TextView>
 
-		<!-- radio text -->
-		<TextView android:layout_width="fill_parent"
-			android:layout_height="wrap_content"
-			android:textSize="16dp" android:id="@+id/RTTextView" android:gravity="center" 		
-			android:paddingLeft="16dp" android:paddingRight="16dp"
-			android:singleLine="true" android:ellipsize="marquee"
-		    android:scrollHorizontally="true" android:paddingTop="12dp"
-		    android:marqueeRepeatLimit="marquee_forever"
-		    android:includeFontPadding="false"></TextView>
-	</LinearLayout>
+        <!-- radio text -->
+        <TextView android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:textSize="16dp" android:id="@+id/RTTextView" android:gravity="center"
+            android:paddingLeft="16dp" android:paddingRight="16dp"
+            android:singleLine="true" android:ellipsize="marquee"
+            android:scrollHorizontally="true" android:paddingTop="12dp"
+            android:marqueeRepeatLimit="marquee_forever"
+            android:includeFontPadding="false"></TextView>
+    </LinearLayout>
 
-	<!-- buttons -->
-	<LinearLayout android:id="@+id/TopRow"
-		android:layout_height="wrap_content" android:layout_width="fill_parent"
-		android:gravity="center_horizontal|bottom|end" android:paddingBottom="0dp"
-		android:paddingTop="32dp">
-		<LinearLayout android:layout_width="fill_parent"
-			android:layout_height="wrap_content" android:layout_weight="1"
-			android:gravity="center">
-			<ImageButton android:layout_height="64dp" android:layout_weight="1"
-				android:layout_width="wrap_content" android:id="@+id/ScanDown"
-				android:src="@drawable/backwardbutton" style="?android:attr/borderlessButtonStyle" />
-		</LinearLayout>
-		<LinearLayout android:layout_width="fill_parent"
-			android:layout_height="wrap_content" android:layout_weight="1"
-			android:gravity="center">
-			<ImageButton android:layout_height="64dp" android:layout_weight="1"
-				android:layout_width="wrap_content" android:id="@+id/Favorite"
-				android:src="@drawable/favoritebutton" style="?android:attr/borderlessButtonStyle" />
-		</LinearLayout>
-		<LinearLayout android:layout_width="fill_parent"
-			android:layout_height="wrap_content" android:layout_weight="1"
-			android:gravity="center">
-			<ImageButton android:layout_height="64dp" android:layout_weight="1"
-				android:layout_width="wrap_content" android:id="@+id/Pause"
-				android:src="@drawable/pausebutton" style="?android:attr/borderlessButtonStyle" />
-		</LinearLayout>
-		<LinearLayout android:layout_width="fill_parent"
-			android:layout_height="wrap_content" android:layout_weight="1"
-			android:gravity="center">
-			<ImageButton android:layout_height="64dp" android:layout_weight="1"
-				android:layout_width="wrap_content" android:id="@+id/ScanUp"
-				android:src="@drawable/forwardbutton" style="?android:attr/borderlessButtonStyle" />
-		</LinearLayout>
-	</LinearLayout>
-</LinearLayout> 
+    <!-- buttons -->
+    <LinearLayout android:id="@+id/TopRow"
+        android:layout_height="wrap_content" android:layout_width="fill_parent"
+        android:gravity="center_horizontal|bottom|end" android:paddingBottom="0dp"
+        android:paddingTop="32dp">
+        <LinearLayout android:layout_width="fill_parent"
+            android:layout_height="wrap_content" android:layout_weight="1"
+            android:gravity="center">
+            <ImageButton android:layout_height="64dp" android:layout_weight="1"
+                android:layout_width="wrap_content" android:id="@+id/ScanDown"
+                android:src="@drawable/backwardbutton" style="?android:attr/borderlessButtonStyle" />
+        </LinearLayout>
+        <LinearLayout android:layout_width="fill_parent"
+            android:layout_height="wrap_content" android:layout_weight="1"
+            android:gravity="center">
+            <ImageButton android:layout_height="64dp" android:layout_weight="1"
+                android:layout_width="wrap_content" android:id="@+id/Favorite"
+                android:src="@drawable/favoritebutton" style="?android:attr/borderlessButtonStyle" />
+        </LinearLayout>
+        <LinearLayout android:layout_width="fill_parent"
+            android:layout_height="wrap_content" android:layout_weight="1"
+            android:gravity="center">
+            <ImageButton android:layout_height="64dp" android:layout_weight="1"
+                android:layout_width="wrap_content" android:id="@+id/Pause"
+                android:src="@drawable/pausebutton" style="?android:attr/borderlessButtonStyle" />
+        </LinearLayout>
+        <LinearLayout android:layout_width="fill_parent"
+            android:layout_height="wrap_content" android:layout_weight="1"
+            android:gravity="center">
+            <ImageButton android:layout_height="64dp" android:layout_weight="1"
+                android:layout_width="wrap_content" android:id="@+id/ScanUp"
+                android:src="@drawable/forwardbutton" style="?android:attr/borderlessButtonStyle" />
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/res/values-pt-rPT/strings.xml
+++ b/res/values-pt-rPT/strings.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Effem</string>
+    <string name="band_select">Seleccionar Banda</string>
+    <string name="band_us">USA</string>
+    <string name="band_eu">Europa</string>
+    <string name="band_ja">Japão</string>
+    <string name="band_ch">China</string>
+    <string name="station_select">Seleccionar Estação</string>
+    <string name="fmradio">FM RADIO</string>
+    <string name="dashes">- - - -</string>
+    <string name="no_rds">SEM RDS</string>
+    <string name="no_stations">Sem estações guardadas</string>
+    <string name="scan_error">Não é possível iniciar a procura</string>
+    <string name="fm_start_error">Não é possível iniciar o receptor de rádio</string>
+    <string name="seek_error">Incapaz de procurar estações</string>
+    <string name="resume_error">Incapaz de resumir</string>
+    <string name="pause_error">Incapaz de pausar</string>
+    <string name="busy_error">Ocupadado, por favor tente mais tarde</string>
+    <string name="no_headset_error">Por favor connecte os headphones/headset</string>
+    <string-array name="pty_names">
+        <item>Desconhecido</item>
+        <item>Notícias</item>
+        <item>Assuntos actuais</item>
+        <item>Informação</item>
+        <item>Desporto</item>
+        <item>Educação</item>
+        <item>Drama</item>
+        <item>Cultura</item>
+        <item>Ciência</item>
+        <item>Variado</item>
+        <item>Pop</item>
+        <item>Rock</item>
+        <item>Música Ligeira</item>
+        <item>Clássica Ligeira</item>
+        <item>Música clássica</item>
+        <item>Outra música</item>
+        <item>Meteorologia</item>
+        <item>Finanças</item>
+        <item>Crianças</item>
+        <item>Assuntos sociais</item>
+        <item>Religião</item>
+        <item>Discos pedidos</item>
+        <item>Viagens</item>
+        <item>Lazer</item>
+        <item>Jazz</item>
+        <item>Country</item>
+        <item>Nacional</item>
+        <item>Oldies</item>
+        <item>Folk</item>
+        <item>Documentário</item>
+        <item>Teste de Alarme</item>
+        <item>Alarme</item>
+    </string-array>
+</resources>

--- a/src/com/cyanogenmod/effem/FmRadioService.java
+++ b/src/com/cyanogenmod/effem/FmRadioService.java
@@ -61,7 +61,7 @@ public class FmRadioService extends Service {
     private FmReceiver.OnStartedListener mReceiverStartedListener;
     private BroadcastReceiver mHeadsetReceiver;
 
-	private int mCurrentFrequency;
+    private int mCurrentFrequency;
     private boolean mCallbacksEnabled = false;
     private boolean mHeadsetConnected = false;
 
@@ -141,12 +141,12 @@ public class FmRadioService extends Service {
         super.onDestroy();
     }
 
-	@Override
-	public int onStartCommand(Intent intent, int flags, int startId) {
-		return Service.START_STICKY;
-	}
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        return Service.START_STICKY;
+    }
 
-	@Override
+    @Override
     public IBinder onBind(Intent arg0) {
         mHandler = new Handler();
         return mBinder;
@@ -189,7 +189,7 @@ public class FmRadioService extends Service {
                 if (rdsData.containsKey("PSN")) {
                     setNotification(rdsData.getString("PSN").trim(), mCurrentFrequency);
                 }
-                
+
             }
         };
 
@@ -431,12 +431,12 @@ public class FmRadioService extends Service {
         if (stationName != null && frequency > 0) {
             mRadioNotification.setContentTitle(stationName)
                 .setContentText(freqFormatted + " MHz");
-            mNotificationInstance = mRadioNotification.build();
+            mNotificationInstance = mRadioNotification.getNotification();
             mNotificationManager.notify(PLAY_NOTIFICATION, mNotificationInstance);
         } else if (frequency > 0) {
             mRadioNotification.setContentTitle(freqFormatted + " MHz")
                 .setContentText("");
-            mNotificationInstance = mRadioNotification.build();
+            mNotificationInstance = mRadioNotification.getNotification();
             mNotificationManager.notify(PLAY_NOTIFICATION, mNotificationInstance);
         }
     }


### PR DESCRIPTION
Portuguese translations..

Woops, I only wanted to add the Pt translations, although the commit to fix the compiling errors in ICS came along with it.
Regarding the compilation errors in ICS, it is because in the TextView of the frequency, there is no android:fontFamily in ICS (lines 28/29 of main.xml), and the Notification.Builder.build() does not exist in ICS, although is just a new name for Notification.Builder.getNotification() which exists in ICS+ but deprecated in JB.
Any chance to maintain backward compatibility with ICS?
